### PR TITLE
Test that the metadata checker capture the missing data source key

### DIFF
--- a/DISDRODB/METADATA/EPFL/GENEPI_2007/metadata/7484.yml
+++ b/DISDRODB/METADATA/EPFL/GENEPI_2007/metadata/7484.yml
@@ -1,4 +1,3 @@
-data_source: EPFL
 campaign_name: GENEPI_2007
 station_name: "7484"
 sensor_name: PARSIVEL


### PR DESCRIPTION
This PR is used to test if the metadata checker capture the missing data source key

 
